### PR TITLE
feat: adopt Renovate best practices policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,21 @@ Add a `renovate.json5` file to your repository root:
 
 This preset provides:
 
-- `config:recommended` base preset
+- `config:best-practices` base preset
 - Semantic commit type set to `chore`
 - Dependency Dashboard disabled
-- Scheduled updates on weekends (Asia/Bangkok timezone)
-- Grouped and auto-merged updates for selected package families
-- Lock file maintenance enabled and auto-merged
+- Scheduled updates on Friday and Saturday nights in the Asia/Bangkok timezone
+- Docker image digest pinning, keeping tags as the intended update stream
+- GitHub Actions pinning to full commit SHAs while preserving Renovate's version comments
+- Pinned npm `devDependencies`
+- npm minimum release age from Renovate's security preset, currently three days
+- Renovate configuration migration PRs
+- Abandoned dependency detection
+- Weekly lockfile maintenance during the configured update window, with manual review required
+- No general third-party dependency automerge
+- Grouped automerge only for `@davidsneighbour/*` and `@dnbhq/*` packages, after normal Renovate checks such as npm minimum release age
+
+Security updates handled specially by Renovate should keep Renovate's normal security behavior; this preset does not add a custom delay override for them.
 
 See [`default.json`](./default.json) for full details.
 

--- a/default.json
+++ b/default.json
@@ -5,8 +5,9 @@
   "schedule": [
     "* 21-23,0-4 * * 5,6"
   ],
+  "automerge": false,
   "extends": [
-    "config:recommended",
+    "config:best-practices",
     ":semanticCommitTypeAll(chore)",
     ":disableDependencyDashboard"
   ],
@@ -17,12 +18,6 @@
   ],
   "onboarding": false,
   "packageRules": [
-    {
-      "automerge": true,
-      "matchPackageNames": [
-        "/@types/*/"
-      ]
-    },
     {
       "automerge": true,
       "automergeSchedule": [
@@ -43,7 +38,7 @@
       "groupName": "davidsneighbour",
       "ignoreTests": true,
       "matchPackageNames": [
-        "/@davidsneighbour/*/"
+        "@davidsneighbour/**"
       ]
     },
     {
@@ -66,15 +61,7 @@
       "groupName": "dnbhq",
       "ignoreTests": true,
       "matchPackageNames": [
-        "/@dnbhq/*/"
-      ]
-    },
-    {
-      "automerge": true,
-      "matchPackageNames": [
-        "/lint/",
-        "/prettier/",
-        "/caniuse-lite/"
+        "@dnbhq/**"
       ]
     },
     {
@@ -93,7 +80,10 @@
   "additionalBranchPrefix": "{{parentDir}}/",
   "lockFileMaintenance": {
     "enabled": true,
-    "automerge": true,
+    "automerge": false,
+    "schedule": [
+      "* 21-23,0-4 * * 5,6"
+    ],
     "commitMessageAction": "build(deps): update lockfile dependencies"
   }
 }


### PR DESCRIPTION
## Summary

- migrate the shared preset base from config:recommended to config:best-practices
- inherit immutable Docker digest pinning and GitHub Actions full-SHA pinning from Renovate best practices
- keep Renovate's npm minimum release age protection at three days and avoid custom security-delay overrides
- remove broad third-party automerge for @types, lint tools, Prettier, and caniuse-lite
- retain grouped automerge for @davidsneighbour/* and @dnbhq/* packages, including at-any-time automerge and existing update types
- keep weekly lockfile maintenance but require manual review, scheduled inside the existing Friday/Saturday Asia/Bangkok update window so it remains runnable

## Validation

- npm install
- npm run verify